### PR TITLE
fix: restore consumer API packaging + CLI parity fixes

### DIFF
--- a/clang_tool_chain_bins/__init__.py
+++ b/clang_tool_chain_bins/__init__.py
@@ -277,3 +277,31 @@ __all__ = [
     "resolve_one",
     "try_install",
 ]
+
+# Rust native bindings (available when built with maturin)
+try:
+    from clang_tool_chain_bins._native import (  # noqa: F401
+        create_tar_zst,
+        expand_archive,
+        generate_checksum_files,
+        lfs_media_url,
+        md5_file,
+        read_platform_manifest,
+        sha256_file,
+        sha256_verify,
+        update_platform_manifest,
+    )
+
+    __all__ += [
+        "expand_archive",
+        "create_tar_zst",
+        "sha256_file",
+        "md5_file",
+        "sha256_verify",
+        "generate_checksum_files",
+        "read_platform_manifest",
+        "update_platform_manifest",
+        "lfs_media_url",
+    ]
+except ImportError:
+    pass

--- a/clang_tool_chain_bins/cli.py
+++ b/clang_tool_chain_bins/cli.py
@@ -1,0 +1,76 @@
+"""CLI shims that delegate to the Rust `ctcb` binary."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _binary_name() -> str:
+    return "ctcb.exe" if sys.platform == "win32" else "ctcb"
+
+
+def _find_binary() -> Path:
+    """Find the ctcb binary: check alongside Python executable first, then PATH."""
+    exe_dir = Path(sys.executable).parent
+    candidate = exe_dir / _binary_name()
+    if candidate.exists():
+        return candidate
+
+    # Search PATH
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(path_dir) / _binary_name()
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError(
+        f"Could not find {_binary_name()}. "
+        "Install with: cargo install --path crates/ctcb-cli"
+    )
+
+
+def _run(subcommand: str) -> None:
+    """Run a ctcb subcommand, forwarding all arguments."""
+    binary = _find_binary()
+    result = subprocess.run(
+        [str(binary), subcommand, *sys.argv[1:]],
+        check=False,
+    )
+    sys.exit(result.returncode)
+
+
+def fetch_and_archive() -> None:
+    _run("fetch")
+
+def download_binaries() -> None:
+    _run("download")
+
+def strip_binaries() -> None:
+    _run("strip")
+
+def deduplicate_binaries() -> None:
+    _run("dedup")
+
+def create_hardlink_archive() -> None:
+    _run("hardlink-archive")
+
+def expand_archive() -> None:
+    _run("expand")
+
+def test_compression() -> None:
+    _run("bench-compression")
+
+def create_iwyu_archives() -> None:
+    _run("iwyu")
+
+def extract_mingw_sysroot() -> None:
+    _run("mingw-sysroot")
+
+def emscripten() -> None:
+    _run("emscripten")
+
+def emscripten_docker() -> None:
+    _run("emscripten-docker")
+
+def nodejs() -> None:
+    _run("nodejs")

--- a/crates/ctcb-cli/src/main.rs
+++ b/crates/ctcb-cli/src/main.rs
@@ -487,9 +487,16 @@ fn main() -> anyhow::Result<()> {
             no_strip,
             verbose,
         } => {
+            // Support combined format "win-x86_64" for backward compatibility
+            let (plat_str, arch_str) = if platform.contains('-') {
+                let parts: Vec<&str> = platform.splitn(2, '-').collect();
+                (parts[0].to_string(), parts[1].to_string())
+            } else {
+                (platform, arch)
+            };
             let target = ctcb_core::Target::new(
-                ctcb_core::Platform::from_str_loose(&platform)?,
-                ctcb_core::Arch::from_str_loose(&arch)?,
+                ctcb_core::Platform::from_str_loose(&plat_str)?,
+                ctcb_core::Arch::from_str_loose(&arch_str)?,
             );
             let config = ctcb_strip::StripConfig {
                 target,
@@ -1150,8 +1157,9 @@ fn main() -> anyhow::Result<()> {
                 if !status.success() {
                     anyhow::bail!("7z extraction failed");
                 }
+            } else if ext == "tar.gz" {
+                ctcb_download::extract_tar_gz(&download_path, &extract_dir)?;
             } else {
-                // tar.xz and tar.gz both handled by system tar
                 ctcb_download::extract_tar_xz(&download_path, &extract_dir)?;
             }
 
@@ -1167,7 +1175,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
             // Remove non-essential files
-            for pattern in &["README.md", "CHANGELOG.md", "LICENSE"] {
+            for pattern in &["README.md", "CHANGELOG.md"] {
                 let f = node_root.join(pattern);
                 if f.exists() {
                     std::fs::remove_file(&f)?;

--- a/crates/ctcb-download/src/lib.rs
+++ b/crates/ctcb-download/src/lib.rs
@@ -192,6 +192,29 @@ pub fn extract_tar_xz(archive: &Path, output_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Extract a tar.gz archive
+pub fn extract_tar_gz(archive: &Path, output_dir: &Path) -> Result<()> {
+    println!("Extracting {}...", archive.display());
+    fs::create_dir_all(output_dir)?;
+
+    let status = Command::new("tar")
+        .args([
+            "xzf",
+            &archive.to_string_lossy(),
+            "-C",
+            &output_dir.to_string_lossy(),
+        ])
+        .status()
+        .context("Failed to run tar")?;
+
+    if !status.success() {
+        bail!("tar extraction failed with exit code {:?}", status.code());
+    }
+
+    println!("Extracted to {}", output_dir.display());
+    Ok(())
+}
+
 /// Download and extract LLVM for a single platform.
 /// Returns the path to the extracted directory.
 pub fn download_platform(

--- a/crates/ctcb-strip/src/lib.rs
+++ b/crates/ctcb-strip/src/lib.rs
@@ -33,11 +33,11 @@ pub const ESSENTIAL_BINARIES: &[&str] = &[
     "llvm-strip",
     "llvm-readelf",
     "llvm-readobj",
+    "llvm-dlltool",
+    "llvm-lib",
     // Additional utilities
     "llvm-as",
     "llvm-dis",
-    "clang-format",
-    "clang-tidy",
     "llvm-symbolizer",
     "llvm-config",
 ];
@@ -183,7 +183,8 @@ fn copy_essential_files(
                     || name.contains(".so.")
                     || name.ends_with(".dll")
                     || name.ends_with(".dylib");
-                let is_removable = REMOVE_LIB_EXTENSIONS.iter().any(|ext| name.ends_with(ext));
+                let is_removable = REMOVE_LIB_EXTENSIONS.iter().any(|ext| name.ends_with(ext))
+                    || name == "CMakeLists.txt";
 
                 if is_dynamic {
                     fs::copy(entry.path(), dst_lib.join(&name))?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,11 @@ build-backend = "maturin"
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]
-python-source = "python"
 module-name = "clang_tool_chain_bins._native"
 manifest-path = "crates/ctcb-cli/Cargo.toml"
 
 [tool.pytest.ini_options]
-testpaths = ["python/tests"]
+testpaths = ["tests", "python/tests"]
 
 [tool.uv]
 dev-dependencies = [


### PR DESCRIPTION
Fixes #5 (partial — addresses H8, M4, M5, M14, M15 plus critical packaging regression)

## What broke
The maturin migration only packaged `python/clang_tool_chain_bins/` in the wheel, breaking:
- `from tools import ...` (all legacy tests failed)
- `from clang_tool_chain_bins import query, install` (consumer API missing)

## What this fixes
- **Packaging**: maturin now includes `tools/` and root `clang_tool_chain_bins/` in wheel
- **H8**: Remove clang-format/clang-tidy from ESSENTIAL_BINARIES; add llvm-dlltool/llvm-lib
- **M4**: Accept combined platform format (win-x86_64) in strip command
- **M5**: Filter CMakeLists.txt from lib directories
- **M14**: Preserve LICENSE in Node.js packages
- **M15**: Add extract_tar_gz() for macOS Node.js downloads

## Test results
- 53 Rust tests passing
- 66 Python tests passing (was 8 before this fix — 58 tests were broken by packaging)
- 119 total