### PR TITLE
test: comprehensive manifest validation matching consumer API contract

### DIFF
--- a/tests/test_manifest_integrity.py
+++ b/tests/test_manifest_integrity.py
@@ -1,14 +1,30 @@
 """
-Manifest integrity tests — validates that all published manifests have
-the required fields for the consumer API (clang-tool-chain) to work.
+Manifest integrity tests — validates that all published manifests conform to
+the contract expected by the consumer API (clang-tool-chain).
 
-These tests reproduce the exact errors found in clang-tool-chain CI:
-- Bug 1: LLDB manifests have latest=null (KeyError: None)
-- Bug 2: IWYU parts missing per-part sha256 (KeyError: 'sha256')
-- Bug 3: clang-extra missing linux/arm64 (RuntimeError: platform not found)
+These tests run in CI to catch manifest issues BEFORE they reach downstream.
+If a test here fails, the downstream clang-tool-chain project WILL break.
+
+Consumer contract (from clang_tool_chain/manifest.py + installers/base.py):
+
+Root manifest:
+  - platforms[].platform: str (REQUIRED)
+  - platforms[].architectures[].arch: str (REQUIRED)
+  - platforms[].architectures[].manifest_path: str (points to platform manifest)
+
+Platform manifest:
+  - latest: str (REQUIRED, must not be null, must reference existing version)
+  - Version entries (flat keys or nested "versions" dict):
+    - href: str (REQUIRED, download URL)
+    - sha256: str (REQUIRED, hex hash)
+    - parts[]: optional, for multi-part archives
+      - parts[].href: str (REQUIRED)
+      - parts[].sha256: str (REQUIRED)
+      - parts[].size: int (optional)
 """
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -20,104 +36,205 @@ def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _iter_platform_manifests(tool: str):
-    """Yield (platform, arch, manifest_dict) for every platform manifest of a tool."""
-    root_manifest_path = ASSETS / tool / "manifest.json"
-    if not root_manifest_path.exists():
-        pytest.skip(f"No root manifest for {tool}")
-    root = _load_json(root_manifest_path)
+def _iter_tools():
+    """Yield (tool_name, tool_dir) for each tool in assets/."""
+    for d in sorted(ASSETS.iterdir()):
+        if d.is_dir() and (d / "manifest.json").exists():
+            yield d.name, d
+
+
+def _iter_platform_manifests(tool_dir: Path):
+    """Yield (platform, arch, manifest_path, manifest_dict) for every platform manifest."""
+    root = _load_json(tool_dir / "manifest.json")
     for plat_entry in root.get("platforms", []):
         platform = plat_entry["platform"]
         for arch_entry in plat_entry.get("architectures", []):
             arch = arch_entry["arch"]
-            if "manifest_path" not in arch_entry:
-                continue  # Some root manifests use a different schema
-            manifest_path = ASSETS / tool / arch_entry["manifest_path"]
+            rel_path = arch_entry.get("manifest_path")
+            if not rel_path:
+                continue
+            manifest_path = tool_dir / rel_path
             if not manifest_path.exists():
                 pytest.fail(f"Platform manifest missing: {manifest_path}")
-            yield platform, arch, _load_json(manifest_path)
+            yield platform, arch, manifest_path, _load_json(manifest_path)
 
 
-class TestManifestIntegrity:
-    """Every published platform manifest must have valid data for the consumer API."""
+def _get_versions(manifest: dict) -> dict:
+    """Extract version entries from either flat or nested manifest format."""
+    if "versions" in manifest and isinstance(manifest["versions"], dict):
+        return manifest["versions"]
+    return {k: v for k, v in manifest.items()
+            if k != "latest" and isinstance(v, dict)}
 
-    def test_all_platform_manifests_have_non_null_latest(self):
-        """Bug 1 repro: manifest.versions[manifest.latest] fails when latest is None."""
-        for tool_dir in ASSETS.iterdir():
-            if not tool_dir.is_dir():
-                continue
-            tool = tool_dir.name
-            for platform, arch, manifest in _iter_platform_manifests(tool):
-                latest = manifest.get("latest")
-                assert latest is not None, (
-                    f"{tool}/{platform}/{arch}: 'latest' is null/missing. "
-                    f"Consumer does manifest.versions[manifest.latest] which raises KeyError: None"
+
+# ===========================================================================
+# Root manifest validation
+# ===========================================================================
+
+class TestRootManifests:
+    """Every root manifest must have valid structure."""
+
+    def test_root_manifests_have_platforms_array(self):
+        for tool, tool_dir in _iter_tools():
+            root = _load_json(tool_dir / "manifest.json")
+            assert "platforms" in root, (
+                f"{tool}/manifest.json: missing 'platforms' key"
+            )
+            assert isinstance(root["platforms"], list), (
+                f"{tool}/manifest.json: 'platforms' must be an array"
+            )
+
+    def test_platform_entries_have_required_fields(self):
+        for tool, tool_dir in _iter_tools():
+            root = _load_json(tool_dir / "manifest.json")
+            for i, plat in enumerate(root.get("platforms", [])):
+                assert "platform" in plat, (
+                    f"{tool}/manifest.json: platforms[{i}] missing 'platform'"
                 )
-                # If latest is set, it must exist as a version key
-                # Manifest formats: either flat (version keys at same level as "latest")
-                # or nested (under "versions" dict)
-                if "versions" in manifest and isinstance(manifest["versions"], dict):
-                    version_keys = list(manifest["versions"].keys())
-                else:
-                    version_keys = [k for k in manifest if k != "latest"]
-                if version_keys:
-                    assert latest in version_keys, (
-                        f"{tool}/{platform}/{arch}: latest='{latest}' but "
-                        f"available versions are {version_keys}"
+                assert "architectures" in plat, (
+                    f"{tool}/manifest.json: platforms[{i}] ({plat.get('platform')}) "
+                    f"missing 'architectures'"
+                )
+                for j, arch in enumerate(plat.get("architectures", [])):
+                    assert "arch" in arch, (
+                        f"{tool}/manifest.json: platforms[{i}].architectures[{j}] "
+                        f"missing 'arch'"
                     )
 
-    def test_all_manifest_parts_have_sha256(self):
-        """Bug 2 repro: p['sha256'] fails when parts lack per-part sha256."""
-        for tool_dir in ASSETS.iterdir():
-            if not tool_dir.is_dir():
-                continue
-            tool = tool_dir.name
-            for platform, arch, manifest in _iter_platform_manifests(tool):
-                # Handle both flat and nested manifest formats
-                if "versions" in manifest and isinstance(manifest["versions"], dict):
-                    versions = manifest["versions"]
-                else:
-                    versions = {k: v for k, v in manifest.items()
-                                if k != "latest" and isinstance(v, dict)}
-                for version_key, version_info in versions.items():
-                    parts = version_info.get("parts", [])
-                    for i, part in enumerate(parts):
+    def test_manifest_path_entries_point_to_existing_files(self):
+        for tool, tool_dir in _iter_tools():
+            root = _load_json(tool_dir / "manifest.json")
+            for plat in root.get("platforms", []):
+                for arch in plat.get("architectures", []):
+                    rel = arch.get("manifest_path")
+                    if not rel:
+                        continue
+                    full = tool_dir / rel
+                    assert full.exists(), (
+                        f"{tool}: root manifest references '{rel}' but file "
+                        f"does not exist at {full}"
+                    )
+
+
+# ===========================================================================
+# Platform manifest validation
+# ===========================================================================
+
+class TestPlatformManifests:
+    """Every platform manifest must satisfy the consumer API contract."""
+
+    def test_latest_is_not_null(self):
+        """Consumer does manifest.versions[manifest.latest] — null latest = KeyError: None."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                latest = manifest.get("latest")
+                assert latest is not None, (
+                    f"{tool}/{plat}/{arch}: 'latest' is null. "
+                    f"Consumer does manifest.versions[manifest.latest] -> KeyError: None"
+                )
+
+    def test_latest_references_existing_version(self):
+        """Consumer does manifest.versions[manifest.latest] — must find the key."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                latest = manifest.get("latest")
+                if not latest:
+                    continue
+                versions = _get_versions(manifest)
+                assert latest in versions, (
+                    f"{tool}/{plat}/{arch}: latest='{latest}' not in versions "
+                    f"{list(versions.keys())}"
+                )
+
+    def test_version_entries_have_href(self):
+        """Consumer accesses version_info.href — must exist."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    assert "href" in info, (
+                        f"{tool}/{plat}/{arch} v{ver}: missing 'href'"
+                    )
+
+    def test_version_entries_have_sha256(self):
+        """Consumer accesses version_info.sha256 — must exist."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    assert "sha256" in info, (
+                        f"{tool}/{plat}/{arch} v{ver}: missing 'sha256'"
+                    )
+
+    def test_sha256_is_valid_hex(self):
+        """SHA256 must be a 64-character hex string."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    sha = info.get("sha256", "")
+                    assert re.fullmatch(r"[0-9a-fA-F]{64}", sha), (
+                        f"{tool}/{plat}/{arch} v{ver}: sha256 '{sha}' is not "
+                        f"a valid 64-char hex string"
+                    )
+
+    def test_href_is_valid_url(self):
+        """href must be a URL starting with https://."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    href = info.get("href", "")
+                    assert href.startswith("https://"), (
+                        f"{tool}/{plat}/{arch} v{ver}: href '{href}' must "
+                        f"start with https://"
+                    )
+
+
+# ===========================================================================
+# Multi-part archive validation
+# ===========================================================================
+
+class TestMultipartArchives:
+    """Multi-part archives must have per-part href and sha256."""
+
+    def test_parts_have_href(self):
+        """Consumer does p['href'] on each part."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    for i, part in enumerate(info.get("parts", [])):
+                        assert "href" in part, (
+                            f"{tool}/{plat}/{arch} v{ver} part[{i}]: "
+                            f"missing 'href'"
+                        )
+
+    def test_parts_have_sha256(self):
+        """Consumer does p['sha256'] on each part — KeyError if missing."""
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    for i, part in enumerate(info.get("parts", [])):
                         assert "sha256" in part, (
-                            f"{tool}/{platform}/{arch} version {version_key} "
-                            f"part[{i}] missing 'sha256'. "
-                            f"Consumer does p['sha256'] which raises KeyError. "
+                            f"{tool}/{plat}/{arch} v{ver} part[{i}]: "
+                            f"missing 'sha256'. Consumer does p['sha256'] -> KeyError. "
                             f"Part: {part}"
                         )
 
-    def test_all_root_manifest_entries_have_valid_platform_manifests(self):
-        """Every platform listed in a root manifest must have a valid platform manifest file."""
-        for tool_dir in ASSETS.iterdir():
-            if not tool_dir.is_dir():
-                continue
-            root_path = tool_dir / "manifest.json"
-            if not root_path.exists():
-                continue
-            root = _load_json(root_path)
-            for plat_entry in root.get("platforms", []):
-                for arch_entry in plat_entry.get("architectures", []):
-                    if "manifest_path" not in arch_entry:
-                        continue
-                    pm_path = tool_dir / arch_entry["manifest_path"]
-                    assert pm_path.exists(), (
-                        f"{tool_dir.name}: root manifest references "
-                        f"{arch_entry['manifest_path']} but file does not exist"
-                    )
-                    pm = _load_json(pm_path)
-                    latest = pm.get("latest")
-                    if latest is not None:
-                        # If latest is set, verify the version entry exists
-                        if "versions" in pm:
-                            assert latest in pm["versions"], (
-                                f"{tool_dir.name}/{arch_entry['manifest_path']}: "
-                                f"latest='{latest}' not in versions"
-                            )
-                        else:
-                            assert latest in pm, (
-                                f"{tool_dir.name}/{arch_entry['manifest_path']}: "
-                                f"latest='{latest}' not found as key"
-                            )
+    def test_part_sha256_is_valid_hex(self):
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    for i, part in enumerate(info.get("parts", [])):
+                        sha = part.get("sha256", "")
+                        assert re.fullmatch(r"[0-9a-fA-F]{64}", sha), (
+                            f"{tool}/{plat}/{arch} v{ver} part[{i}]: "
+                            f"sha256 '{sha}' is not valid hex"
+                        )
+
+    def test_part_hrefs_are_valid_urls(self):
+        for tool, tool_dir in _iter_tools():
+            for plat, arch, path, manifest in _iter_platform_manifests(tool_dir):
+                for ver, info in _get_versions(manifest).items():
+                    for i, part in enumerate(info.get("parts", [])):
+                        href = part.get("href", "")
+                        assert href.startswith("https://"), (
+                            f"{tool}/{plat}/{arch} v{ver} part[{i}]: "
+                            f"href '{href}' must start with https://"
+                        )


### PR DESCRIPTION
Refs #7, #9

## What this adds

13 tests that enforce the exact manifest contract expected by the `clang-tool-chain` consumer. These run in CI on every PR — any manifest change that would break downstream is caught HERE before it ships.

### Tests by category

| Category | Tests | What it catches |
|----------|-------|----------------|
| Root manifests | 3 | Missing platforms/arch fields, dangling manifest_path |
| Platform manifests | 6 | null latest (Bug 1), missing href/sha256, invalid hex, bad URLs |
| Multi-part archives | 4 | Missing per-part sha256 (Bug 2), invalid part URLs |

### Why this matters

Without these tests, manifest issues silently ship and only surface as crashes in the downstream `clang-tool-chain` project. This happened with LLDB (KeyError: None), IWYU (KeyError: sha256), and Valgrind.

79 total tests passing (13 new + 66 existing).