### PR TITLE
feat: bump to v0.4.0 + crates.io publish support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-archive"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-checksum"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "md-5",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-cli"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-core"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-dedup"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-download"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-manifest"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-split"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-strip"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ctcb-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
+license = "MIT"
+repository = "https://github.com/zackees/clang-tool-chain-bins"
+homepage = "https://github.com/zackees/clang-tool-chain-bins"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/crates/ctcb-archive/Cargo.toml
+++ b/crates/ctcb-archive/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-archive"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Tar and zstd archive creation/extraction for clang toolchain binary builder"
 
 [dependencies]
 tar = { workspace = true }

--- a/crates/ctcb-checksum/Cargo.toml
+++ b/crates/ctcb-checksum/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-checksum"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SHA256 and MD5 file hashing for clang toolchain binary builder"
 
 [dependencies]
 sha2 = { workspace = true }

--- a/crates/ctcb-cli/Cargo.toml
+++ b/crates/ctcb-cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-cli"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "CLI and Python bindings for clang toolchain binary builder"
 
 [[bin]]
 name = "ctcb"

--- a/crates/ctcb-core/Cargo.toml
+++ b/crates/ctcb-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-core"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Platform detection and shared types for clang toolchain binary builder"
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/ctcb-dedup/Cargo.toml
+++ b/crates/ctcb-dedup/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-dedup"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "File deduplication via hardlinks for clang toolchain binary builder"
 
 [dependencies]
 md-5 = { workspace = true }

--- a/crates/ctcb-download/Cargo.toml
+++ b/crates/ctcb-download/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-download"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "HTTP download with progress for clang toolchain binary builder"
 
 [dependencies]
 reqwest = { workspace = true }

--- a/crates/ctcb-manifest/Cargo.toml
+++ b/crates/ctcb-manifest/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-manifest"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Two-tier manifest JSON management for clang toolchain binary builder"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/ctcb-split/Cargo.toml
+++ b/crates/ctcb-split/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-split"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Archive splitting for Git LFS limits for clang toolchain binary builder"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/ctcb-strip/Cargo.toml
+++ b/crates/ctcb-strip/Cargo.toml
@@ -3,6 +3,10 @@ name = "ctcb-strip"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "LLVM binary stripping and filtering for clang toolchain binary builder"
 
 [dependencies]
 walkdir = { workspace = true }

--- a/publish
+++ b/publish
@@ -1,32 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Publish clang-tool-chain-bins by triggering remote CI builds,
-# downloading artifacts, and uploading to PyPI.
-#
-# Usage:
-#   ./publish              # trigger builds, download wheels, upload to PyPI
-#   ./publish --dry-run    # trigger builds, download wheels, don't upload
-#
-# Prerequisites:
-#   - gh CLI authenticated
-#   - PYPI_TOKEN env var set (or use trusted publishing via GitHub Actions)
-
 cd "$(dirname "$0")"
 
-VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 TAG="v${VERSION}"
 DRY_RUN=""
+SKIP_RUST=""
 
-if [[ "${1:-}" == "--dry-run" ]]; then
-    DRY_RUN="true"
-    echo "DRY RUN — will not upload to PyPI"
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN="true"; shift ;;
+        --skip-rust) SKIP_RUST="true"; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
 
-echo "Publishing ${REPO} ${TAG}"
+echo "=== Publishing ${REPO} v${VERSION} ==="
 
-# Verify clean and pushed
+# Check clean tree
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "ERROR: working tree is dirty" >&2
     exit 1
@@ -39,34 +32,63 @@ if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
     exit 1
 fi
 
-# Tag and push
+# Check PyPI for existing version
+echo "Checking PyPI for existing version..."
+EXISTING=$(curl -s "https://pypi.org/pypi/clang-tool-chain-bins/${VERSION}/json" 2>/dev/null && echo "exists" || echo "new")
+if [[ "$EXISTING" == *"exists"* ]]; then
+    echo "WARNING: Version ${VERSION} already exists on PyPI"
+fi
+
+# Publish Rust crates first (if not skipped)
+if [[ -z "$SKIP_RUST" ]]; then
+    echo ""
+    echo "=== Publishing Rust crates to crates.io ==="
+    CRATES=(ctcb-core ctcb-checksum ctcb-archive ctcb-dedup ctcb-download ctcb-strip ctcb-manifest ctcb-split ctcb-cli)
+    for crate in "${CRATES[@]}"; do
+        echo "  Publishing $crate..."
+        if [[ -n "$DRY_RUN" ]]; then
+            cargo publish -p "$crate" --no-verify --dry-run 2>&1 | tail -1
+        else
+            cargo publish -p "$crate" --no-verify 2>&1 | tail -1
+            if [[ "$crate" != "${CRATES[-1]}" ]]; then
+                echo "  Waiting for crates.io to index..."
+                sleep 30
+            fi
+        fi
+    done
+fi
+
+# Tag and push to trigger release workflow
+echo ""
+echo "=== Tagging and pushing ==="
 if git rev-parse "$TAG" >/dev/null 2>&1; then
     echo "Tag $TAG already exists"
 else
     echo "Creating tag $TAG"
-    git tag "$TAG"
-    git push origin "$TAG"
+    if [[ -z "$DRY_RUN" ]]; then
+        git tag "$TAG"
+        git push origin "$TAG"
+    else
+        echo "  (dry run — skipping tag)"
+    fi
 fi
 
-echo "Tag pushed — release.yml will trigger automatically."
-echo "Monitor at: https://github.com/${REPO}/actions"
 echo ""
+echo "=== Release workflow triggered ==="
+echo "The release.yml workflow will:"
+echo "  1. Build wheels for 5 targets:"
+echo "     - x86_64-unknown-linux-gnu"
+echo "     - aarch64-unknown-linux-gnu (via zig)"
+echo "     - x86_64-pc-windows-msvc"
+echo "     - x86_64-apple-darwin"
+echo "     - aarch64-apple-darwin"
+echo "  2. Build sdist"
+echo "  3. Create GitHub Release with binaries + wheels + checksums"
+echo "  4. Publish to PyPI via trusted publishing"
+echo ""
+echo "Monitor: https://github.com/${REPO}/actions"
 
 if [[ -n "$DRY_RUN" ]]; then
-    echo "Dry run complete. The release workflow will:"
-    echo "  1. Build wheels for 5 targets (linux x64/arm64, windows x64, macos x64/arm64)"
-    echo "  2. Build sdist"
-    echo "  3. Create GitHub Release with binaries + wheels"
-    echo "  4. Publish to PyPI (if 'release' environment is configured)"
-    exit 0
+    echo ""
+    echo "DRY RUN complete — no changes made."
 fi
-
-echo "Release workflow triggered. It will automatically:"
-echo "  1. Build wheels for 5 targets"
-echo "  2. Create GitHub Release"
-echo "  3. Publish to PyPI via trusted publishing"
-echo ""
-echo "To publish manually instead, download artifacts and run:"
-echo "  gh run download <run-id> --pattern 'wheel-*' --dir dist"
-echo "  gh run download <run-id> --pattern 'sdist' --dir dist"
-echo "  uv publish dist/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clang-tool-chain-bins"
-version = "0.3.0"
+version = "0.4.0"
 description = "LLVM/Clang Toolchain Build Tools - Rust-powered toolchain packaging with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/clang_tool_chain_bins/__init__.py
+++ b/python/clang_tool_chain_bins/__init__.py
@@ -1,6 +1,6 @@
 """Clang Toolchain Binary Builder - Rust-powered toolchain packaging."""
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"
 
 # Try to import native bindings (available when built with maturin)
 try:


### PR DESCRIPTION
## Changes

- **Version**: 0.3.0 -> 0.4.0 (Rust migration = minor bump, reset patch)
- **Crate metadata**: All 9 crates now have license/repository/homepage/description for crates.io
- **Publish script**: Comprehensive `./publish` matching running-process pattern:
  - Publishes 9 Rust crates to crates.io in dependency order
  - Tags and pushes to trigger release.yml
  - release.yml builds wheels for 5 targets + sdist, creates GitHub Release, publishes to PyPI

## Platform support

| Target | Wheel | Binary | Status |
|--------|-------|--------|--------|
| x86_64-unknown-linux-gnu | Yes | Yes | Tested in CI |
| aarch64-unknown-linux-gnu | Yes (zig) | Yes | Tested in CI |
| x86_64-pc-windows-msvc | Yes | Yes | Tested in CI |
| x86_64-apple-darwin | Yes | Yes | Tested in CI |
| aarch64-apple-darwin | Yes | Yes | Tested in CI |
| aarch64-pc-windows-msvc | No | No | Missing ARM64 Python SDK |

## Tests
- 53 Rust tests + 79 Python tests = 132 total, all passing