### PR TITLE
ci(release): opt setup-soldr into platform-default linker

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -202,6 +202,15 @@ jobs:
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}
+          # Opt out of soldr's `fast` linker default. `fast` injects
+          # `-fuse-ld=lld` which Clang on macOS rejects ("invalid linker
+          # name"), failing the cdylib link step of ctcb-cli. The
+          # platform-default value tells setup-soldr to leave the linker
+          # choice to cargo/rust-toolchain.toml. See
+          # https://github.com/zackees/clang-tool-chain-bins/issues (release
+          # pipeline hardening) and the soldr 'fast' linker note in the
+          # action description.
+          linker: platform-default
 
       - name: Ensure target stdlib is installed
         shell: bash


### PR DESCRIPTION
## Summary

Fix the release pipeline's macOS builds by opting `setup-soldr` out of the `fast` linker default.

`fast` injects `-fuse-ld=lld`, which Clang on macOS rejects:

```
clang: error: invalid linker name in argument '-fuse-ld=lld'
error: could not compile `ctcb-cli` (lib) due to 1 previous error
```

…failing the `cdylib` link step of `ctcb-cli` for both `x86_64-apple-darwin` and `aarch64-apple-darwin` in the release matrix (see run [26056031321](https://github.com/zackees/clang-tool-chain-bins/actions/runs/26056031321)).

## Why the earlier in-script retry didn't help

The hardening branch's fallback set `SOLDR_LINKER=platform-default` directly as an env var, but soldr itself only accepts `{default, ld, mold, rust-lld, fast}` — the `platform-default` opt-out value is interpreted by **the setup-soldr action**, not the soldr binary. Result: the retry also failed with `invalid SOLDR_LINKER value 'platform-default'`.

## Fix

Pass `linker: platform-default` to the `setup-soldr` action input. The action then defers linker choice to cargo / `rust-toolchain.toml`, restoring the native default linker on all 8 release targets.

## Test plan

- [ ] CI for this PR builds all 8 matrix targets successfully (especially the two macOS ones).
- [ ] Merge to `main`; verify push-to-main run skips release (version unchanged) but builds green.
- [ ] Tag `v0.4.2` → release publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)