### PR TITLE
chore: bump to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-archive"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-checksum"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "md-5",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-dedup"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-download"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-manifest"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-split"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-strip"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "ctcb-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/ctcb-archive/Cargo.toml
+++ b/crates/ctcb-archive/Cargo.toml
@@ -15,7 +15,7 @@ walkdir = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
 flate2 = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-cli/Cargo.toml
+++ b/crates/ctcb-cli/Cargo.toml
@@ -19,14 +19,14 @@ crate-type = ["cdylib", "rlib"]
 clap = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.2" }
-ctcb-archive = { path = "../ctcb-archive", version = "0.4.2" }
-ctcb-dedup = { path = "../ctcb-dedup", version = "0.4.2" }
-ctcb-download = { path = "../ctcb-download", version = "0.4.2" }
-ctcb-strip = { path = "../ctcb-strip", version = "0.4.2" }
-ctcb-manifest = { path = "../ctcb-manifest", version = "0.4.2" }
-ctcb-split = { path = "../ctcb-split", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.3" }
+ctcb-archive = { path = "../ctcb-archive", version = "0.4.3" }
+ctcb-dedup = { path = "../ctcb-dedup", version = "0.4.3" }
+ctcb-download = { path = "../ctcb-download", version = "0.4.3" }
+ctcb-strip = { path = "../ctcb-strip", version = "0.4.3" }
+ctcb-manifest = { path = "../ctcb-manifest", version = "0.4.3" }
+ctcb-split = { path = "../ctcb-split", version = "0.4.3" }
 walkdir = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ctcb-dedup/Cargo.toml
+++ b/crates/ctcb-dedup/Cargo.toml
@@ -14,8 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }
 anyhow = { workspace = true }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.2" }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.3" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-download/Cargo.toml
+++ b/crates/ctcb-download/Cargo.toml
@@ -14,5 +14,5 @@ tokio = { workspace = true }
 sha2 = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
 futures-util = { workspace = true }

--- a/crates/ctcb-manifest/Cargo.toml
+++ b/crates/ctcb-manifest/Cargo.toml
@@ -12,7 +12,7 @@ description = "Two-tier manifest JSON management for clang toolchain binary buil
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-split/Cargo.toml
+++ b/crates/ctcb-split/Cargo.toml
@@ -12,8 +12,8 @@ description = "Archive splitting for Git LFS limits for clang toolchain binary b
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-strip/Cargo.toml
+++ b/crates/ctcb-strip/Cargo.toml
@@ -11,7 +11,7 @@ description = "LLVM binary stripping and filtering for clang toolchain binary bu
 [dependencies]
 walkdir = { workspace = true }
 anyhow = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.2" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clang-tool-chain-bins"
-version = "0.4.2"
+version = "0.4.3"
 description = "LLVM/Clang Toolchain Build Tools - Rust-powered toolchain packaging with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump workspace + Python package version from 0.4.2 to 0.4.3 so a clean tag can drive the PyPI/crates.io publish.

**Why a fresh version (not retag v0.4.2):**

The `v0.4.2` tag points at `b63226c`, the squash-merge of #22 which only captured the first of the PR's two commits. The auto-merge fired on the first push before the cc-rs musl fix (`6bc5527`) was pushed to the PR branch, so the merge commit on main was missing it. As a result:

- v0.4.2 tag-driven release ([run 26104864938](https://github.com/zackees/clang-tool-chain-bins/actions/runs/26104864938)) failed `Build (aarch64-unknown-linux-musl)` with `libgcc_s.so.1 => not found` — same error as before #22.
- PyPI never saw 0.4.2 (publish job blocked by `needs:[build]`).
- The fix was subsequently landed via #23 (`e79ad4a`), so main now has both fixes.

Cutting v0.4.3 avoids re-pointing the v0.4.2 tag and gives PyPI/crates.io a clean monotonic version.

## Changes

- `pyproject.toml` 0.4.2 → 0.4.3
- `Cargo.toml` `[workspace.package].version` 0.4.2 → 0.4.3
- Inter-crate path-dep version pins in 8 `crates/*/Cargo.toml` files
- `Cargo.lock` regenerated via `cargo update --workspace --offline`

## Test plan

- [ ] Existing CI runs green on PR
- [ ] Merge → push tag `v0.4.3` → auto-release publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)