### PR TITLE
chore: ignore .claude/ local runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ cython_debug/
 # uv
 uv.lock
 work/
+
+# Claude Code local runtime state
+.claude/worktrees/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Adds selective `.gitignore` entries for Claude Code local runtime artifacts (`.claude/worktrees/`, `.claude/scheduled_tasks.lock`)
- Keeps the door open for tracking real `.claude/` project config later (no blanket `.claude/` ignore)

## Test plan
- [x] `git status` no longer reports `.claude/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)