### PR TITLE
ci: bump setup-soldr v0.9.24 → v0.9.35 (~7s warm-run win)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary

Bumps `zackees/setup-soldr` from v0.9.24 → v0.9.35 in `.github/workflows/auto-release.yml`.

Picks up two upstream perf wins:
- **#302/#303** — sub-phase timing observability
- **#304/#308** — FS-first rustup probe, eliminates ~7s `rustup toolchain list` subprocess per warm CI run

Validated on zccache CI: linux/Test wall clock 30.0s → 14.8s (-15.2s).

## Test plan

- [ ] CI green on this PR
- [ ] Auto-release workflow still produces ctcb binaries for all matrix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)