### PR TITLE
ci: bump setup-soldr v0.9.35 → v0.9.44

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.44
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Bump `zackees/setup-soldr` from v0.9.35 to v0.9.44 in `.github/workflows/auto-release.yml`.
- Picks up the solo-toolchain-cache + hardlink wins (#305-#335).
- ~13s/warm-job saved on workflows using setup-soldr.

## Test plan
- [ ] CI green on this PR's release matrix
- [ ] Warm-job toolchain restore visibly faster in Actions logs

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>