### PR TITLE
ci: bump setup-soldr v0.9.44 → v0.9.46

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.44
+        uses: zackees/setup-soldr@v0.9.46
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary

- Bumps `zackees/setup-soldr` from v0.9.44 to v0.9.46 in `.github/workflows/auto-release.yml`.
- v0.9.46 flips the `solo-toolchain-cache` default to `true` (setup-soldr#343/#344).
- This repo doesn't explicitly set the input, so the new default activates automatically — saves ~8-11s per warm CI job with no further changes.

## Test plan

- [ ] CI auto-release workflow runs green on this PR.
- [ ] Inspect a warm-job log post-merge to confirm solo-toolchain-cache layer participates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)