### PR TITLE
ci: bump setup-soldr v0.9.46 → v0.9.47

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.46
+        uses: zackees/setup-soldr@v0.9.47
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` pin from v0.9.46 to v0.9.47 in `.github/workflows/auto-release.yml`.
- Picks up setup-soldr#347/#348 — new `cache-eviction-policy` input (defaults to disabled; behavior unchanged for this repo).

## Test plan
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)