### PR TITLE
ci: bump setup-soldr v0.9.47 -> v0.9.48 (cache-eviction age floor fix)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
Picks up setup-soldr#352/#353 — cache-eviction-policy age floor fix. This repo doesn't enable the policy, so no behavior change.