### PR TITLE
ci: bump setup-soldr v0.9.48 -> v0.9.49

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.48` to `v0.9.49`.

## What's in v0.9.49
- `cache-eviction-policy: protect-foundations` thresholds raised from 9 GB / 8 GB to 9.5 GB / 9.0 GB.
- Reason: v0.9.48 was leaving ~2 GB of usable cache budget on the table. New thresholds keep 0.5 GB headroom under GitHub's 10 GB cap and fire eviction less eagerly while still beating GitHub's own non-deterministic LRU. The 6h age floor from v0.9.48 is unchanged.

No action input changes; this is a pure threshold tuning that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green (warm restore + post-step eviction logs)
- [ ] Post-step eviction log shows new thresholds (`evicting toward 9 GB` when usage > 9.5 GB) — or no eviction at all if usage stays under 9.5 GB
