### PR TITLE
ci: bump setup-soldr v0.9.50 -> v0.9.53

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.50` to `v0.9.53`.

## What's in v0.9.51–v0.9.53
- **v0.9.51** — Per-line `MM:SS` timestamps on `soldr cook` output (cargo's `Compiling`/`Downloading` lines), colors preserved (diagnostic).
- **v0.9.52** — Per-layer save table now splits `compress` vs `upload` wall-clock for cook-cache (diagnostic).
- **v0.9.53** — **PERF WIN**: cook-cache-base compression level dropped from zstd-19 → zstd-9. Cuts post-step compress wall-clock ~4× (~165s → ~40s on zccache observation) at the cost of ~25% larger archive (~280 MB instead of ~224 MB). zstd decompression is level-independent, so warm restores unaffected. Net: ~125s win per save-attempt, with multiplier on race-loss matrix scenarios.

## Test plan
- [ ] CI green
- [ ] Post-step `compress` column in save table shows ~40s instead of ~165s for cook-cache-base
- [ ] Setup phase total drops on cold-cook runs
