### PR TITLE
ci: bump setup-soldr v0.9.53 -> v0.9.55

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.53
+        uses: zackees/setup-soldr@v0.9.55
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.53` to `v0.9.55`.

## What's in v0.9.54–v0.9.55
- **v0.9.54** — Extended per-layer split-timing (compress vs upload columns) to build-cache and cargo-registry (diagnostic).
- **v0.9.55** — **PERF**: setup-soldr now auto-derives `parentSha` from `git log -1 --format=%P HEAD` when `ACTION_PARENT_SHA` env var isn't set. This activates the cook-cache-delta, target-cache, and cargo-registry parent-SHA fallback restore keys that were previously inert (production observation: cook-cache-delta had 0% hit rate across 6 jobs in 3 runs). Closes setup-soldr#365.

## Test plan
- [ ] CI green
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears in the log (instead of `(no parent-fallback ...)`)
- [ ] Second commit after this lands: cook-cache-delta restore should HIT against this commit's saved entry (instead of MISS)
