### PR TITLE
ci: bump setup-soldr v0.9.55 -> v0.9.56

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.55` to `v0.9.56`.

## What's in v0.9.56
Fixes v0.9.55's parentSha derivation on shallow checkouts (the default `actions/checkout` config with `fetch-depth: 1`). Production observation on zccache MSRV (run 26799669322):
```
parent-sha: unexpected git output "\n"; leaving empty
cook: layered keys ... (no parent-fallback — parentSha unavailable, #365)
cook-cache-delta MISS
```

`git log -1 --format=%P HEAD` returns empty for grafted root commits on shallow clones. v0.9.56 adds a `git cat-file -p HEAD` fallback that parses the raw commit object — its `parent` header line is preserved even when the parent commit isn't fetched. This finally activates the cook-cache-delta / target-cache / cargo-registry parent-SHA fallback restore keys.

## Test plan
- [ ] CI green
- [ ] Log shows `parent-sha: derived <sha> from cat-file (#365, shallow-safe)`
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears
- [ ] Second commit after this lands: cook-cache-delta should HIT against this commit's saved entry
