### PR TITLE
ci: bump setup-soldr v0.9.59 -> v0.9.60

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.59
+        uses: zackees/setup-soldr@v0.9.60
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.59` to `v0.9.60`.

## What's in v0.9.60 — perf win
Parallelize cache-eviction deletes with concurrency=10. Sequential `cache.deleteActionsCacheById` API calls were observed at ~190ms each on busy repos. zccache CI was spending ~57s in the eviction delete-loop for 300 entries. After this change, the same loop completes in ~6s.

Per-CI-cycle savings: ~50s × matrix-job-count of post-step wall-clock on the over-budget path. zccache MSRV alone saves ~50s; full matrix saves ~5×50s = ~250s of aggregate post-step time.

## Test plan
- [ ] CI green
- [ ] Eviction log on over-budget runs shows the delete loop completing in <10s instead of 50-60s
