### PR TITLE
ci: bump setup-soldr v0.9.61 -> v0.9.62

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Soldr (rustup + cached toolchain + zccache state)
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           cache-key-suffix: release-${{ matrix.target }}


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.61` to `v0.9.62`.

## What's in v0.9.62 — perf win
Drops per-job suffix from cargo-registry cache key (closes setup-soldr#375).

cargo-registry content is `$CARGO_HOME/registry/` + `.global-cache` + `git/` — keyed on Cargo.lock content, identical across matrix jobs (check, test, doc, msrv all download the same crates). Per-job suffix made each job save its own ~56 MB copy.

Production observation on zccache 9-job matrix: ~500 MB redundant uploads per CI cycle. After this fix: first job saves, rest exact-HIT (was FALLBACK with redundant save).

Mirrors #371 (drop SHA from same key) and #237 (drop SHA from build-cache). build-cache KEEPS suffix because target/ content differs per job; cargo-registry does not.

## Test plan
- [ ] CI green
- [ ] First cache-saving job in matrix shows cargo-registry SAVED; subsequent jobs show SKIPPED-RACE (instead of FALLBACK+SAVED)
- [ ] Aggregate cargo-registry uploads per CI cycle drops from ~500 MB to ~56 MB
