### PR TITLE
feat: package clangd in clang-extra archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
           uv run --no-sync maturin develop --release
       - name: Run Python tests
         run: uv run --no-sync pytest python/tests/ -v
+      - name: Validate clang-extra builder
+        run: uv run --no-sync pytest tests/test_clang_extra_builder.py -v
       - name: PEP 517 backend smoke (soldr builds the wheel)
         if: matrix.os == 'ubuntu-latest'
         run: uv build --wheel

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Public API functions:
 
 ## Query CLI
 
+`clangd` is distributed in the `clang-extra` component for Windows x86_64,
+Linux x86_64/ARM64, and macOS x86_64/ARM64. This is the native language
+server; installing the VS Code extension alone does not provide this binary.
+
+```bash
+clang-tool-chain-bins query clangd --component clang-extra --platform linux --arch x86_64
+clang-tool-chain-bins install clangd --component clang-extra --platform linux --arch x86_64
+```
+
+The archive includes the Clang resource headers and runtime libraries needed
+by `clangd`, so the installation does not depend on a system LLVM tree.
+
 `query` is the discovery command. Default JSONL output returns one matched entry per line.
 
 - Patterns without glob characters are exact matches.

--- a/clang_tool_chain_bins/_impl/archive_index.py
+++ b/clang_tool_chain_bins/_impl/archive_index.py
@@ -148,6 +148,14 @@ def _parse_sha256_sidefile(path: Path) -> str | None:
     return content.split()[0]
 
 
+def _load_provenance(archive_path: Path) -> dict[str, Any] | None:
+    path = Path(f"{archive_path}.provenance.json")
+    if not path.exists():
+        return None
+    data = _load_json(path)
+    return data if isinstance(data, dict) else None
+
+
 def _write_sha256_sidefile(path: Path, sha256: str, archive_name: str) -> None:
     path.write_text(f"{sha256}  {archive_name}\n", encoding="utf-8")
 
@@ -204,6 +212,7 @@ def _materialized_archive_path(archive_path: Path, manifest_info: ManifestArchiv
 def index_archive(archive_path: Path, assets_root: Path, manifest_lookup: dict[str, ManifestArchiveInfo]) -> dict[str, Any]:
     component, platform, arch = _infer_component_platform_arch(archive_path, assets_root)
     manifest_info = manifest_lookup.get(archive_path.name)
+    provenance = _load_provenance(archive_path)
     pointer_info = parse_git_lfs_pointer(archive_path)
     archive_sha256 = pointer_info["sha256"] if pointer_info else sha256_file(archive_path)
     part_asset_paths: list[Path] = []
@@ -295,6 +304,7 @@ def index_archive(archive_path: Path, assets_root: Path, manifest_lookup: dict[s
             "manifest_path": manifest_info.manifest_path if manifest_info else None,
             "parts": manifest_info.parts if manifest_info else [],
             "git_lfs_pointer": bool(pointer_info),
+            "provenance": provenance,
         },
         "file_count": len(files),
         "tool_count": len(tools),
@@ -349,6 +359,7 @@ def build_aggregate_index(assets_root: Path | None = None, output_path: Path | N
                 "download_kind": archive.get("download_kind"),
                 "probe_urls": archive.get("probe_urls", []),
                 "parts": archive.get("parts", []),
+                "provenance": archive.get("provenance"),
                 "index_path": str(sidecar_path.relative_to(root)),
                 "tool_count": data.get("tool_count", 0),
                 "file_count": data.get("file_count", 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 # Query/install frontend (Python, runtime modules live in clang_tool_chain_bins._impl)
 clang-tool-chain-bins = "clang_tool_chain_bins._impl.cli:main"
 clang-tool-chain-bins-index = "clang_tool_chain_bins._impl.archive_index:main"
+create-clang-extra-archives = "tools.create_clang_extra_archives:main"
 
 # Rust-backed CLI shims (delegate to ctcb binary)
 fetch-and-archive = "clang_tool_chain_bins.cli:fetch_and_archive"

--- a/tests/test_clang_extra_builder.py
+++ b/tests/test_clang_extra_builder.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import stat
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+import pyzstd
+
+from tools.create_clang_extra_archives import EXTRA_TOOLS, SUPPORTED_TARGETS, build_archive, stage_clang_extra
+
+
+class ClangExtraBuilderTests(unittest.TestCase):
+    def _source(self, root: Path, platform: str = "linux") -> Path:
+        (root / "bin").mkdir(parents=True)
+        (root / "lib" / "clang" / "21" / "include").mkdir(parents=True)
+        for name in EXTRA_TOOLS:
+            path = root / "bin" / (name + (".exe" if platform == "win" else ""))
+            path.write_bytes(name.encode())
+            if platform != "win":
+                path.chmod(0o755)
+        (root / "lib" / "clang" / "21" / "include" / "stddef.h").write_text("#pragma once\n")
+        (root / "lib" / "libLLVM.so.21").write_bytes(b"runtime")
+        return root
+
+    def test_allowlist_and_runtime_are_staged_with_executable_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._source(Path(directory) / "llvm")
+            staging = Path(directory) / "staging"
+            provenance = stage_clang_extra(source, staging, "linux", "x86_64", "21.1.5")
+            self.assertEqual(provenance["method"], "extracted")
+            self.assertEqual(sorted(p.name for p in (staging / "bin").iterdir()), sorted(EXTRA_TOOLS))
+            self.assertTrue((staging / "lib" / "clang" / "21" / "include" / "stddef.h").exists())
+            self.assertTrue((staging / "lib" / "libLLVM.so.21").exists())
+            if not __import__("sys").platform.startswith("win"):
+                for path in (staging / "bin").iterdir():
+                    self.assertTrue(path.stat().st_mode & stat.S_IXUSR)
+
+    def test_archive_contains_tools_resources_and_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self._source(root / "llvm")
+            archive = build_archive(source, root / "assets", "linux", "x86_64", "21.1.5")
+            with archive.open("rb") as raw, pyzstd.ZstdFile(raw) as compressed, tarfile.open(fileobj=compressed, mode="r|") as tar:
+                members = {member.name: member for member in tar}
+            self.assertEqual({f"bin/{name}" for name in EXTRA_TOOLS}, {name for name in members if name.startswith("bin/")})
+            self.assertTrue(members["bin/clangd"].mode & stat.S_IXUSR)
+            self.assertIn("lib/clang/21/include/stddef.h", members)
+            provenance = json.loads(Path(f"{archive}.provenance.json").read_text())
+            self.assertEqual(provenance["llvm_version"], "21.1.5")
+            manifest = json.loads((root / "assets" / "linux" / "x86_64" / "manifest.json").read_text())
+            self.assertEqual(manifest["latest"], "21.1.5")
+            self.assertEqual(manifest["versions"]["21.1.5"]["sha256"], (Path(f"{archive}.sha256").read_text().split()[0]))
+
+    def test_missing_binary_fails_loudly(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._source(Path(directory) / "llvm")
+            (source / "bin" / "clangd").unlink()
+            with self.assertRaises(FileNotFoundError):
+                stage_clang_extra(source, Path(directory) / "staging", "linux", "x86_64", "21.1.5")
+
+    def test_supported_targets_are_exactly_issue_allowlist(self) -> None:
+        self.assertEqual(SUPPORTED_TARGETS, {
+            ("win", "x86_64"), ("linux", "x86_64"), ("linux", "arm64"),
+            ("darwin", "x86_64"), ("darwin", "arm64"),
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/README.md
+++ b/tools/README.md
@@ -19,6 +19,28 @@ python fetch_and_archive.py --platform win --arch x86_64 --source-dir ./extracte
 python fetch_and_archive.py --platform linux --arch arm64
 ```
 
+### `create_clang_extra_archives.py`
+
+Builds the `clang-extra` component from one extracted, version-pinned LLVM
+distribution. It keeps the five existing developer tools plus `clangd`, copies
+the matching `lib/clang/<version>` resource directory and runtime libraries,
+forces executable modes in the TAR, and writes a provenance sidecar.
+
+```bash
+python tools/create_clang_extra_archives.py \
+  --source-dir ./LLVM-21.1.5-Linux-X64 \
+  --output-dir ./assets/clang-extra \
+  --platform linux --arch x86_64 --version 21.1.5
+
+# Rebuild sidecars and both packaged index locations afterwards.
+python -m clang_tool_chain_bins._impl.archive_index
+```
+
+The source directory must come from the matching official LLVM release (or a
+Forge build using the same pinned `llvm-project` revision). The builder fails
+if any allowlisted tool or resource directory is missing; it never falls back
+to a system LLVM installation.
+
 **What it does:**
 1. Downloads LLVM from GitHub (or uses `--source-dir`)
 2. Extracts archive

--- a/tools/create_clang_extra_archives.py
+++ b/tools/create_clang_extra_archives.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Build the small, runtime-complete ``clang-extra`` distribution.
+
+The input is an extracted official LLVM distribution (or a directory produced
+by the Forge fallback).  Keeping the selection here, instead of copying an
+already-installed clang, makes the archive reproducible and prevents a host
+LLVM installation from leaking into the artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import stat
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pyzstd
+
+SUPPORTED_TARGETS = {
+    ("win", "x86_64"),
+    ("linux", "x86_64"),
+    ("linux", "arm64"),
+    ("darwin", "x86_64"),
+    ("darwin", "arm64"),
+}
+EXTRA_TOOLS = ("clang-format", "clang-query", "clang-tidy", "git-clang-format", "run-clang-tidy", "clangd")
+LLVM_DOWNLOAD_URLS = {
+    ("win", "x86_64"): "LLVM-{version}-win64.exe",
+    ("linux", "x86_64"): "LLVM-{version}-Linux-X64.tar.xz",
+    ("linux", "arm64"): "clang+llvm-{version}-aarch64-linux-gnu.tar.xz",
+    ("darwin", "x86_64"): "LLVM-{version}-macOS-X64.tar.xz",
+    ("darwin", "arm64"): "LLVM-{version}-macOS-ARM64.tar.xz",
+}
+
+
+def expected_binary_name(platform: str) -> str:
+    return "clangd.exe" if platform == "win" else "clangd"
+
+
+def _find_root(directory: Path) -> Path:
+    if (directory / "bin").is_dir():
+        return directory
+    candidates = sorted(p for p in directory.iterdir() if p.is_dir() and (p / "bin").is_dir())
+    if len(candidates) == 1:
+        return candidates[0]
+    raise ValueError(f"could not identify an LLVM root below {directory}")
+
+
+def _copy_file(source: Path, destination: Path, executable: bool = False) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    if executable:
+        destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def stage_clang_extra(
+    source_dir: Path,
+    staging_dir: Path,
+    platform: str,
+    arch: str,
+    version: str,
+    llvm_commit: str | None = None,
+) -> dict:
+    """Stage tools and all runtime data needed by clangd.
+
+    Missing tools and resource headers are errors: a partial archive is worse
+    than a failed release because it otherwise produces an installable but
+    unusable index entry.
+    """
+    if (platform, arch) not in SUPPORTED_TARGETS:
+        raise ValueError(f"unsupported clang-extra target: {platform}/{arch}")
+    root = _find_root(source_dir)
+    bin_dir = root / "bin"
+    destination_bin = staging_dir / "bin"
+    missing = [name for name in EXTRA_TOOLS if not (bin_dir / (name + (".exe" if platform == "win" else ""))).is_file()]
+    if missing:
+        raise FileNotFoundError(f"LLVM distribution is missing clang-extra tools: {', '.join(missing)}")
+
+    for name in EXTRA_TOOLS:
+        filename = name + (".exe" if platform == "win" else "")
+        _copy_file(bin_dir / filename, destination_bin / filename, platform != "win")
+
+    # clangd loads the Clang resource directory and, on Windows/Unix LLVM
+    # distributions, sibling runtime libraries from these locations.
+    resources = root / "lib" / "clang"
+    if not resources.is_dir():
+        raise FileNotFoundError(f"LLVM resource directory is missing: {resources}")
+    shutil.copytree(resources, staging_dir / "lib" / "clang")
+    for pattern in (("*.dll",) if platform == "win" else ("*.so", "*.so.*", "*.dylib")):
+        for library in sorted((root / "lib").glob(pattern)):
+            _copy_file(library, staging_dir / "lib" / library.name, platform != "win")
+    # Windows LLVM releases keep DLLs beside the executables.
+    if platform == "win":
+        for library in sorted(bin_dir.glob("*.dll")):
+            _copy_file(library, destination_bin / library.name)
+
+    return {
+        "method": "extracted",
+        "llvm_version": version,
+        "llvm_project_tag": f"llvmorg-{version}",
+        "llvm_project_commit": llvm_commit,
+        "llvm_source": "official llvm-project distribution",
+        "target": {"platform": platform, "arch": arch},
+        "tools": list(EXTRA_TOOLS),
+        "build_options": {"mode": "prebuilt-extraction"},
+    }
+
+
+def create_archive(staging_dir: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as raw:
+        tar_path = Path(raw.name)
+    try:
+        def tar_filter(member: tarfile.TarInfo) -> tarfile.TarInfo:
+            if member.isfile() and (member.name.startswith("bin/") or "/bin/" in member.name):
+                member.mode = 0o755
+            elif member.isfile() and (member.name.endswith((".so", ".dylib")) or ".so." in member.name):
+                member.mode = 0o755
+            return member
+
+        with tarfile.open(tar_path, "w") as archive:
+            for path in sorted(staging_dir.rglob("*")):
+                archive.add(path, arcname=path.relative_to(staging_dir).as_posix(), recursive=False, filter=tar_filter)
+        with tar_path.open("rb") as source, output_path.open("wb") as raw_destination, pyzstd.ZstdFile(
+            raw_destination, "w", level_or_option=22
+        ) as destination:
+            shutil.copyfileobj(source, destination)
+    finally:
+        tar_path.unlink(missing_ok=True)
+
+
+def build_archive(
+    source_dir: Path,
+    output_dir: Path,
+    platform: str,
+    arch: str,
+    version: str,
+    llvm_commit: str | None = None,
+) -> Path:
+    filename = f"clang-extra-{version}-{platform}-{arch}.tar.zst"
+    with tempfile.TemporaryDirectory(prefix="clang-extra-") as temporary:
+        staging = Path(temporary) / "staging"
+        provenance = stage_clang_extra(source_dir, staging, platform, arch, version, llvm_commit)
+        output = output_dir / platform / arch / filename
+        create_archive(staging, output)
+        digest = hashlib.sha256(output.read_bytes()).hexdigest()
+        (output.parent / f"{filename}.sha256").write_text(f"{digest}  {filename}\n", encoding="utf-8")
+        (output.parent / f"{filename}.provenance.json").write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
+        update_manifests(output_dir, platform, arch, version, filename, digest)
+    return output
+
+
+def update_manifests(output_dir: Path, platform: str, arch: str, version: str, filename: str, digest: str) -> None:
+    """Update the component and target manifests without losing old versions."""
+    target_dir = output_dir / platform / arch
+    target_manifest = target_dir / "manifest.json"
+    data = json.loads(target_manifest.read_text(encoding="utf-8")) if target_manifest.exists() else {}
+    versions = data.setdefault("versions", {})
+    for key in list(data):
+        if key not in {"latest", "versions"} and isinstance(data[key], dict) and "href" in data[key]:
+            versions.setdefault(key, data.pop(key))
+    versions[version] = {
+        "href": f"https://media.githubusercontent.com/media/zackees/clang-tool-chain-bins/main/assets/clang-extra/{platform}/{arch}/{filename}",
+        "sha256": digest,
+    }
+    data["latest"] = max(versions, key=lambda item: tuple(int(part) for part in item.split(".") if part.isdigit()))
+    target_manifest.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    root_manifest = output_dir / "manifest.json"
+    if root_manifest.exists():
+        root = json.loads(root_manifest.read_text(encoding="utf-8"))
+        platform_entry = next((item for item in root.get("platforms", []) if item.get("platform") == platform), None)
+        if platform_entry is None:
+            platform_entry = {"platform": platform, "architectures": []}
+            root.setdefault("platforms", []).append(platform_entry)
+        if not any(item.get("arch") == arch for item in platform_entry["architectures"]):
+            platform_entry["architectures"].append({"arch": arch, "manifest_path": f"{platform}/{arch}/manifest.json"})
+        root_manifest.write_text(json.dumps(root, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, required=True, help="Extracted official LLVM or Forge staging directory")
+    parser.add_argument("--output-dir", type=Path, default=Path("assets/clang-extra"))
+    parser.add_argument("--platform", choices=sorted({target[0] for target in SUPPORTED_TARGETS}), required=True)
+    parser.add_argument("--arch", choices=sorted({target[1] for target in SUPPORTED_TARGETS}), required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--llvm-commit", help="Resolved llvm-project commit for provenance auditing")
+    args = parser.parse_args(argv)
+    build_archive(args.source_dir, args.output_dir, args.platform, args.arch, args.version, args.llvm_commit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #55

## Summary
- add a reproducible clang-extra packager for all five supported targets
- package clangd with the existing five tools, Clang resources, runtime libraries, checksums, manifests, and provenance
- propagate provenance into archive indexes and test the builder across CI platforms
- document native clangd query/install usage

## Tests
- python -m pytest tests/test_clang_extra_builder.py tests/test_query.py tests/test_api.py -q
- python -m compileall -q tools/create_clang_extra_archives.py clang_tool_chain_bins/_impl/archive_index.py
- full pytest: existing repository asset/index/download fixture failures remain because this checkout lacks several LFS archive sidecars/objects
