### PR TITLE
feat: build and validate clang-extra clangd archives

### DIFF
--- a/.github/workflows/build-clang-extra.yml
+++ b/.github/workflows/build-clang-extra.yml
@@ -1,0 +1,127 @@
+name: Build and validate clang-extra archives
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  official:
+    name: ${{ matrix.platform }}/${{ matrix.arch }} (upstream)
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2025
+            platform: win
+            arch: x86_64
+            version: "21.1.5"
+            commit: 8e2cd28cd4ba46613a46467b0c91b1cabead26cd
+          - runner: ubuntu-24.04
+            platform: linux
+            arch: x86_64
+            version: "21.1.5"
+            commit: 8e2cd28cd4ba46613a46467b0c91b1cabead26cd
+          - runner: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+            version: "21.1.5"
+            commit: 8e2cd28cd4ba46613a46467b0c91b1cabead26cd
+          - runner: macos-14
+            platform: darwin
+            arch: arm64
+            version: "21.1.6"
+            commit: a832a5222e489298337fbb5876f8dcaf072c5cca
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install pyzstd
+      - name: Build from exact upstream distribution
+        run: >-
+          python tools/create_clang_extra_archives.py --download
+          --work-dir tools/work/clang-extra
+          --output-dir out/assets/clang-extra
+          --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
+          --version ${{ matrix.version }} --llvm-commit ${{ matrix.commit }}
+      - name: Generate archive index
+        shell: bash
+        run: >-
+          python -m clang_tool_chain_bins._impl.archive_index
+          --assets-root out/assets
+          --aggregate-output out/tools/data/tool-index.json
+          --meta-output out/tools/data/index-meta.json
+      - name: Native clangd validation
+        run: >-
+          python tools/validate_clang_extra.py
+          out/assets/clang-extra/${{ matrix.platform }}/${{ matrix.arch }}/clang-extra-${{ matrix.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.zst
+          --platform ${{ matrix.platform }} --expected-major 21
+      - uses: actions/upload-artifact@v4
+        with:
+          name: clang-extra-${{ matrix.platform }}-${{ matrix.arch }}
+          path: out
+          if-no-files-found: error
+
+  macos-x86-source:
+    name: darwin/x86_64 (Forge source fallback)
+    runs-on: macos-15-large
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install pyzstd
+      - name: Build pinned clangd source fallback
+        shell: bash
+        run: |
+          brew install cmake ninja
+          git clone --filter=blob:none --no-checkout https://github.com/llvm/llvm-project.git llvm-project
+          git -C llvm-project checkout a832a5222e489298337fbb5876f8dcaf072c5cca
+          cmake -S llvm-project/llvm -B llvm-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra' \
+            -DLLVM_TARGETS_TO_BUILD=X86 \
+            -DLLVM_ENABLE_ASSERTIONS=OFF
+          cmake --build llvm-build --target clangd
+          python - <<'PY'
+          from pathlib import Path
+          import pyzstd, tarfile
+          archive = Path('assets/clang-extra/darwin/x86_64/clang-extra-21.1.6-darwin-x86_64.tar.zst')
+          root = Path('merged')
+          root.mkdir()
+          with archive.open('rb') as raw, pyzstd.ZstdFile(raw) as compressed, tarfile.open(fileobj=compressed, mode='r|') as tar:
+              tar.extractall(root)
+          (root / 'bin').mkdir(exist_ok=True)
+          (root / 'lib').mkdir(exist_ok=True)
+          import shutil
+          shutil.copy2('llvm-build/bin/clangd', root / 'bin/clangd')
+          shutil.copytree('llvm-build/lib/clang', root / 'lib/clang')
+          PY
+          python tools/create_clang_extra_archives.py \
+            --source-dir merged --output-dir out/assets/clang-extra \
+            --platform darwin --arch x86_64 --version 21.1.6 \
+            --llvm-commit a832a5222e489298337fbb5876f8dcaf072c5cca \
+            --provenance-method forge \
+            --build-options-json '{"generator":"Ninja","build_type":"Release","LLVM_ENABLE_PROJECTS":"clang;clang-tools-extra","LLVM_TARGETS_TO_BUILD":"X86"}'
+      - name: Generate archive index
+        shell: bash
+        run: >-
+          python -m clang_tool_chain_bins._impl.archive_index
+          --assets-root out/assets
+          --aggregate-output out/tools/data/tool-index.json
+          --meta-output out/tools/data/index-meta.json
+      - name: Native clangd validation
+        run: >-
+          python tools/validate_clang_extra.py
+          out/assets/clang-extra/darwin/x86_64/clang-extra-21.1.6-darwin-x86_64.tar.zst
+          --platform darwin --expected-major 21
+      - uses: actions/upload-artifact@v4
+        with:
+          name: clang-extra-darwin-x86_64
+          path: out
+          if-no-files-found: error

--- a/ci/clangd/CMakeLists.txt
+++ b/ci/clangd/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.20)
+project(clangd-source-fallback LANGUAGES NONE)

--- a/ci/clangd/README.md
+++ b/ci/clangd/README.md
@@ -1,0 +1,8 @@
+# clangd Forge fallback
+
+`conanfile.py` pins both the LLVM release tag and the dereferenced
+`llvm-project` commit. Forge runs this recipe on a native runner with
+`LLVM_ENABLE_PROJECTS=clang;clang-tools-extra`, Release configuration, and
+the `clangd` target. The package exports `bin/clangd` and the matching Clang
+resource headers so the archive builder can merge them with the five existing
+`clang-extra` tools.

--- a/ci/clangd/conanfile.py
+++ b/ci/clangd/conanfile.py
@@ -1,0 +1,51 @@
+"""Forge/Conan fallback recipe for targets without an LLVM binary release."""
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.files import copy
+
+
+LLVM_TAG = "llvmorg-21.1.6"
+LLVM_COMMIT = "a832a5222e489298337fbb5876f8dcaf072c5cca"
+
+
+class ClangdConan(ConanFile):
+    name = "clangd"
+    version = "21.1.6"
+    settings = "os", "arch", "compiler", "build_type"
+    requires = ()
+    exports_sources = "CMakeLists.txt"
+
+    def layout(self):
+        self.folders.source = "source"
+        self.folders.build = "build"
+
+    def source(self):
+        self.run("git clone --filter=blob:none https://github.com/llvm/llvm-project.git llvm-project")
+        self.run(f"git -C llvm-project checkout {LLVM_COMMIT}")
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["LLVM_ENABLE_PROJECTS"] = "clang;clang-tools-extra"
+        toolchain.variables["LLVM_TARGETS_TO_BUILD"] = "Native"
+        toolchain.variables["LLVM_ENABLE_ASSERTIONS"] = False
+        toolchain.variables["CMAKE_BUILD_TYPE"] = "Release"
+        toolchain.variables["CMAKE_INSTALL_PREFIX"] = self.package_folder
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder="llvm-project/llvm")
+        cmake.build(target="clangd")
+
+    def package(self):
+        copy(self, "clangd", src=self.build_folder / "bin", dst=self.package_folder / "bin")
+        copy(
+            self,
+            "*",
+            src=self.build_folder / "lib" / "clang" / "21" / "include",
+            dst=self.package_folder / "lib" / "clang" / "21" / "include",
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = ["bin"]

--- a/clang_tool_chain_bins/_impl/archive_index.py
+++ b/clang_tool_chain_bins/_impl/archive_index.py
@@ -385,6 +385,7 @@ def build_aggregate_index(assets_root: Path | None = None, output_path: Path | N
                     "download_kind": archive.get("download_kind"),
                     "probe_urls": archive.get("probe_urls", []),
                     "parts": archive.get("parts", []),
+                    "provenance": archive.get("provenance"),
                 }
             )
 
@@ -402,7 +403,7 @@ def build_aggregate_index(assets_root: Path | None = None, output_path: Path | N
     # Backward-compat: mirror to repo-root tools/data/tool-index.json so the
     # GitHub raw URL used by older wheels keeps resolving (see query.py).
     repo_mirror = Path(__file__).resolve().parents[2] / "tools" / "data" / "tool-index.json"
-    if repo_mirror.parent.is_dir():
+    if output_path is None and repo_mirror.parent.is_dir():
         repo_mirror.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return output
 
@@ -451,7 +452,7 @@ def build_meta_index(assets_root: Path | None = None, output_path: Path | None =
     }
     output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     repo_mirror = Path(__file__).resolve().parents[2] / "tools" / "data" / "index-meta.json"
-    if repo_mirror.parent.is_dir():
+    if output_path is None and repo_mirror.parent.is_dir():
         repo_mirror.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
 clang-tool-chain-bins = "clang_tool_chain_bins._impl.cli:main"
 clang-tool-chain-bins-index = "clang_tool_chain_bins._impl.archive_index:main"
 create-clang-extra-archives = "tools.create_clang_extra_archives:main"
+validate-clang-extra = "tools.validate_clang_extra:main"
+integrate-clang-extra-artifacts = "tools.integrate_clang_extra_artifacts:main"
 
 # Rust-backed CLI shims (delegate to ctcb binary)
 fetch-and-archive = "clang_tool_chain_bins.cli:fetch_and_archive"

--- a/tests/test_clang_extra_builder.py
+++ b/tests/test_clang_extra_builder.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pyzstd
 
+from clang_tool_chain_bins._impl.archive_index import build_aggregate_index, build_meta_index, build_sidecar_indexes
 from tools.create_clang_extra_archives import EXTRA_TOOLS, SUPPORTED_TARGETS, build_archive, stage_clang_extra
 
 
@@ -60,6 +61,22 @@ class ClangExtraBuilderTests(unittest.TestCase):
             (source / "bin" / "clangd").unlink()
             with self.assertRaises(FileNotFoundError):
                 stage_clang_extra(source, Path(directory) / "staging", "linux", "x86_64", "21.1.5")
+
+    def test_generated_sidecar_and_indexes_expose_clangd(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = self._source(root / "llvm")
+            archive = build_archive(source, root / "assets" / "clang-extra", "linux", "x86_64", "21.1.5")
+            build_sidecar_indexes(root / "assets")
+            build_aggregate_index(root / "assets", root / "aggregate.json")
+            build_meta_index(root / "assets", root / "meta.json")
+            sidecar = json.loads(Path(f"{archive}.json").read_text())
+            self.assertEqual([tool["tool_name"] for tool in sidecar["tools"]], sorted(EXTRA_TOOLS))
+            aggregate = json.loads((root / "aggregate.json").read_text())
+            matches = [tool for tool in aggregate["tools"] if tool["tool_name"] == "clangd"]
+            self.assertEqual(len(matches), 1)
+            self.assertEqual(matches[0]["path_in_archive"], "bin/clangd")
+            self.assertEqual(matches[0]["provenance"]["llvm_version"], "21.1.5")
 
     def test_supported_targets_are_exactly_issue_allowlist(self) -> None:
         self.assertEqual(SUPPORTED_TARGETS, {

--- a/tools/README.md
+++ b/tools/README.md
@@ -41,6 +41,19 @@ Forge build using the same pinned `llvm-project` revision). The builder fails
 if any allowlisted tool or resource directory is missing; it never falls back
 to a system LLVM installation.
 
+For native CI/release builds, omit `--source-dir` and use `--download` for the
+four upstream targets. The macOS x86_64 lane uses the pinned source fallback.
+Run `validate-clang-extra` on the native runner before uploading its artifact;
+it checks archive contents, executable mode, `clangd --version`, dependencies,
+and an isolated C++20/WASM-shaped `clangd --check` fixture. After all five
+artifacts pass, integrate them with:
+
+```bash
+integrate-clang-extra-artifacts ./downloaded-artifacts --repo-root .
+```
+
+That command regenerates the five sidecars and both aggregate index locations.
+
 **What it does:**
 1. Downloads LLVM from GitHub (or uses `--source-dir`)
 2. Extracts archive

--- a/tools/create_clang_extra_archives.py
+++ b/tools/create_clang_extra_archives.py
@@ -14,8 +14,10 @@ import hashlib
 import json
 import shutil
 import stat
+import subprocess
 import tarfile
 import tempfile
+import urllib.request
 from pathlib import Path
 
 import pyzstd
@@ -29,16 +31,44 @@ SUPPORTED_TARGETS = {
 }
 EXTRA_TOOLS = ("clang-format", "clang-query", "clang-tidy", "git-clang-format", "run-clang-tidy", "clangd")
 LLVM_DOWNLOAD_URLS = {
-    ("win", "x86_64"): "LLVM-{version}-win64.exe",
-    ("linux", "x86_64"): "LLVM-{version}-Linux-X64.tar.xz",
-    ("linux", "arm64"): "clang+llvm-{version}-aarch64-linux-gnu.tar.xz",
-    ("darwin", "x86_64"): "LLVM-{version}-macOS-X64.tar.xz",
-    ("darwin", "arm64"): "LLVM-{version}-macOS-ARM64.tar.xz",
+    ("win", "x86_64"): "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/LLVM-{version}-win64.exe",
+    ("linux", "x86_64"): "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/LLVM-{version}-Linux-X64.tar.xz",
+    ("linux", "arm64"): "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/LLVM-{version}-Linux-ARM64.tar.xz",
+    ("darwin", "x86_64"): "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/LLVM-{version}-macOS-X64.tar.xz",
+    ("darwin", "arm64"): "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/LLVM-{version}-macOS-ARM64.tar.xz",
 }
 
 
 def expected_binary_name(platform: str) -> str:
     return "clangd.exe" if platform == "win" else "clangd"
+
+
+def download_llvm(platform: str, arch: str, version: str, work_dir: Path) -> Path:
+    """Download the exact upstream distribution used for this target."""
+    try:
+        url = LLVM_DOWNLOAD_URLS[(platform, arch)].format(version=version)
+    except KeyError as error:
+        raise ValueError(f"no upstream LLVM distribution for {platform}/{arch}; use the Forge source fallback") from error
+    work_dir.mkdir(parents=True, exist_ok=True)
+    archive = work_dir / Path(url).name
+    if not archive.exists():
+        urllib.request.urlretrieve(url, archive)
+    return archive
+
+
+def extract_llvm(archive: Path, extract_dir: Path, platform: str) -> Path:
+    """Extract an official release using 7-Zip on Windows or tar.xz elsewhere."""
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    if archive.suffix == ".exe":
+        try:
+            subprocess.run(["7z", "x", str(archive), f"-o{extract_dir}", "-y"], check=True, capture_output=True, text=True)
+        except FileNotFoundError as error:
+            raise RuntimeError("7z is required to extract the Windows LLVM installer") from error
+    elif archive.name.endswith(".tar.xz"):
+        subprocess.run(["tar", "-xJf", str(archive), "-C", str(extract_dir)], check=True)
+    else:
+        raise ValueError(f"unsupported LLVM archive: {archive}")
+    return _find_root(extract_dir)
 
 
 def _find_root(directory: Path) -> Path:
@@ -64,6 +94,8 @@ def stage_clang_extra(
     arch: str,
     version: str,
     llvm_commit: str | None = None,
+    provenance_method: str = "extracted",
+    build_options: dict | None = None,
 ) -> dict:
     """Stage tools and all runtime data needed by clangd.
 
@@ -99,14 +131,14 @@ def stage_clang_extra(
             _copy_file(library, destination_bin / library.name)
 
     return {
-        "method": "extracted",
+        "method": provenance_method,
         "llvm_version": version,
         "llvm_project_tag": f"llvmorg-{version}",
         "llvm_project_commit": llvm_commit,
         "llvm_source": "official llvm-project distribution",
         "target": {"platform": platform, "arch": arch},
         "tools": list(EXTRA_TOOLS),
-        "build_options": {"mode": "prebuilt-extraction"},
+        "build_options": build_options or {"mode": "prebuilt-extraction"},
     }
 
 
@@ -140,11 +172,15 @@ def build_archive(
     arch: str,
     version: str,
     llvm_commit: str | None = None,
+    provenance_method: str = "extracted",
+    build_options: dict | None = None,
 ) -> Path:
     filename = f"clang-extra-{version}-{platform}-{arch}.tar.zst"
     with tempfile.TemporaryDirectory(prefix="clang-extra-") as temporary:
         staging = Path(temporary) / "staging"
-        provenance = stage_clang_extra(source_dir, staging, platform, arch, version, llvm_commit)
+        provenance = stage_clang_extra(
+            source_dir, staging, platform, arch, version, llvm_commit, provenance_method, build_options
+        )
         output = output_dir / platform / arch / filename
         create_archive(staging, output)
         digest = hashlib.sha256(output.read_bytes()).hexdigest()
@@ -152,6 +188,23 @@ def build_archive(
         (output.parent / f"{filename}.provenance.json").write_text(json.dumps(provenance, indent=2) + "\n", encoding="utf-8")
         update_manifests(output_dir, platform, arch, version, filename, digest)
     return output
+
+
+def build_downloaded_archive(
+    output_dir: Path,
+    platform: str,
+    arch: str,
+    version: str,
+    work_dir: Path,
+    llvm_commit: str | None = None,
+    provenance_method: str = "extracted",
+    build_options: dict | None = None,
+) -> Path:
+    """Download, extract, and package one native upstream distribution."""
+    archive = download_llvm(platform, arch, version, work_dir)
+    with tempfile.TemporaryDirectory(prefix="llvm-extract-") as extracted:
+        source = extract_llvm(archive, Path(extracted), platform)
+        return build_archive(source, output_dir, platform, arch, version, llvm_commit, provenance_method, build_options)
 
 
 def update_manifests(output_dir: Path, platform: str, arch: str, version: str, filename: str, digest: str) -> None:
@@ -184,14 +237,41 @@ def update_manifests(output_dir: Path, platform: str, arch: str, version: str, f
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--source-dir", type=Path, required=True, help="Extracted official LLVM or Forge staging directory")
+    source_group = parser.add_mutually_exclusive_group()
+    source_group.add_argument("--source-dir", type=Path, help="Extracted official LLVM or Forge staging directory")
+    source_group.add_argument("--download", action="store_true", help="Download and extract the matching official LLVM distribution")
     parser.add_argument("--output-dir", type=Path, default=Path("assets/clang-extra"))
     parser.add_argument("--platform", choices=sorted({target[0] for target in SUPPORTED_TARGETS}), required=True)
     parser.add_argument("--arch", choices=sorted({target[1] for target in SUPPORTED_TARGETS}), required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--llvm-commit", help="Resolved llvm-project commit for provenance auditing")
+    parser.add_argument("--provenance-method", choices=("extracted", "forge"), default="extracted")
+    parser.add_argument("--build-options-json", help="JSON object recorded in provenance")
+    parser.add_argument("--work-dir", type=Path, default=Path("tools/work/clang-extra"))
     args = parser.parse_args(argv)
-    build_archive(args.source_dir, args.output_dir, args.platform, args.arch, args.version, args.llvm_commit)
+    build_options = json.loads(args.build_options_json) if args.build_options_json else None
+    if args.source_dir is not None:
+        build_archive(
+            args.source_dir,
+            args.output_dir,
+            args.platform,
+            args.arch,
+            args.version,
+            args.llvm_commit,
+            args.provenance_method,
+            build_options,
+        )
+    else:
+        build_downloaded_archive(
+            args.output_dir,
+            args.platform,
+            args.arch,
+            args.version,
+            args.work_dir,
+            args.llvm_commit,
+            args.provenance_method,
+            build_options,
+        )
     return 0
 
 

--- a/tools/integrate_clang_extra_artifacts.py
+++ b/tools/integrate_clang_extra_artifacts.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Integrate validated clang-extra CI artifacts and regenerate all indexes."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from clang_tool_chain_bins._impl.archive_index import (
+    build_aggregate_index,
+    build_manifest_lookup,
+    build_meta_index,
+    write_archive_index,
+)
+
+
+def integrate(artifacts_dir: Path, repo_root: Path) -> list[Path]:
+    source = artifacts_dir / "assets" / "clang-extra"
+    if not source.is_dir():
+        raise FileNotFoundError(f"expected artifact directory {source}")
+    destination = repo_root / "assets" / "clang-extra"
+    archives: list[Path] = []
+    for source_file in sorted(path for path in source.rglob("*") if path.is_file()):
+        relative = source_file.relative_to(source)
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_file, target)
+        if source_file.suffix == ".zst" and source_file.name.endswith(".tar.zst"):
+            archives.append(target)
+
+    lookup = build_manifest_lookup(repo_root / "assets")
+    for archive in archives:
+        write_archive_index(archive, repo_root / "assets", lookup)
+    build_aggregate_index(repo_root / "assets")
+    build_meta_index(repo_root / "assets")
+    return archives
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifacts_dir", type=Path)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    args = parser.parse_args(argv)
+    archives = integrate(args.artifacts_dir.resolve(), args.repo_root.resolve())
+    print(f"integrated {len(archives)} clang-extra archives")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_clang_extra.py
+++ b/tools/validate_clang_extra.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate one real clang-extra archive on its native runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform as host_platform
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pyzstd
+
+REQUIRED_TOOLS = ("clang-format", "clang-query", "clang-tidy", "git-clang-format", "run-clang-tidy")
+
+
+def _binary_name(name: str, target: str) -> str:
+    return name + (".exe" if target == "win" else "")
+
+
+def _extract(archive: Path, destination: Path) -> None:
+    if archive.stat().st_size < 1024:
+        raise AssertionError(f"{archive} is an LFS pointer or otherwise not a real archive")
+    with archive.open("rb") as raw, pyzstd.ZstdFile(raw) as compressed, tarfile.open(fileobj=compressed, mode="r|") as tar:
+        tar.extractall(destination)
+
+
+def validate(archive: Path, target: str, expected_major: str, run_check: bool = True) -> None:
+    with tempfile.TemporaryDirectory(prefix="clang-extra-validate-") as temporary:
+        root = Path(temporary)
+        _extract(archive, root)
+        bin_dir = root / "bin"
+        required = [*_REQUIRED_NAMES(target)]
+        missing = [name for name in required if not (bin_dir / name).is_file()]
+        if missing:
+            raise AssertionError(f"archive is missing tools: {', '.join(missing)}")
+        clangd = bin_dir / _binary_name("clangd", target)
+        if target != "win" and not clangd.stat().st_mode & 0o111:
+            raise AssertionError(f"{clangd} is not executable")
+        environment = os.environ.copy()
+        if target == "linux":
+            environment["LD_LIBRARY_PATH"] = str(root / "lib") + os.pathsep + environment.get("LD_LIBRARY_PATH", "")
+        elif target == "darwin":
+            environment["DYLD_LIBRARY_PATH"] = str(root / "lib") + os.pathsep + environment.get("DYLD_LIBRARY_PATH", "")
+        version = subprocess.run(
+            [str(clangd), "--version"], check=True, capture_output=True, text=True, env=environment
+        ).stdout
+        if f"version {expected_major}." not in version and f"LLVM {expected_major}" not in version:
+            raise AssertionError(f"unexpected clangd version: {version.strip()}")
+
+        if target == "linux":
+            dependencies = subprocess.run(["ldd", str(clangd)], check=True, capture_output=True, text=True).stdout
+            if "not found" in dependencies:
+                raise AssertionError(f"unresolved Linux dependency:\n{dependencies}")
+        elif target == "darwin":
+            dependencies = subprocess.run(["otool", "-L", str(clangd)], check=True, capture_output=True, text=True).stdout
+            if "not found" in dependencies:
+                raise AssertionError(f"unresolved macOS dependency:\n{dependencies}")
+
+        if run_check:
+            fixture = root / "fixture.cpp"
+            fixture.write_text("#include <cstddef>\nint main() { return 0; }\n", encoding="utf-8")
+            (root / "compile_commands.json").write_text(
+                json.dumps([{"directory": str(root), "file": str(fixture), "arguments": ["clang++", "-std=c++20", "-target", "wasm32-wasi", "-c", str(fixture)]}]),
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [str(clangd), f"--check={fixture.name}", f"--compile-commands-dir={root}"],
+                check=True,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+
+def _REQUIRED_NAMES(target: str) -> tuple[str, ...]:
+    return tuple(_binary_name(name, target) for name in (*REQUIRED_TOOLS, "clangd"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("--platform", choices=("win", "linux", "darwin"), required=True)
+    parser.add_argument("--expected-major", required=True)
+    parser.add_argument("--skip-check", action="store_true")
+    args = parser.parse_args(argv)
+    validate(args.archive, args.platform, args.expected_major, not args.skip_check)
+    print(f"validated {args.archive} on {host_platform.platform()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #55

## Summary
- extend the clang-extra builder to download and extract exact upstream LLVM releases
- add a pinned llvm-project source fallback recipe for macOS x86_64
- add native archive validation for modes, tools, versions, dependencies, and clangd --check
- add CI artifact generation and an integration command that regenerates sidecars and packaged indexes

## Validation
- python -m pytest tests/test_clang_extra_builder.py tests/test_query.py tests/test_api.py -q (29 passed)
- python -m compileall -q tools ci/clangd
- YAML parsed successfully

The issue remains open until the manually dispatched native workflow artifacts are integrated into assets, the full packaged indexes are regenerated, and a clean package release is verified.
