### PR TITLE
fix: preserve clang-extra helper script paths

### DIFF
--- a/tools/create_clang_extra_archives.py
+++ b/tools/create_clang_extra_archives.py
@@ -137,7 +137,9 @@ def stage_clang_extra(
         filename = name + (".exe" if platform == "win" else "")
         _copy_file(bin_dir / filename, destination_bin / filename, platform != "win")
     for name in ("git-clang-format", "run-clang-tidy"):
-        filename = name + (".exe" if platform == "win" else "")
+        # These are Python helper scripts, not PE executables. The historical
+        # clang-extra contract exposes them without a platform suffix.
+        filename = name
         source = bin_dir / filename
         if source.is_file():
             _copy_file(source, destination_bin / filename, platform != "win")

--- a/tools/validate_clang_extra.py
+++ b/tools/validate_clang_extra.py
@@ -79,7 +79,8 @@ def validate(archive: Path, target: str, expected_major: str, run_check: bool = 
 
 
 def _REQUIRED_NAMES(target: str) -> tuple[str, ...]:
-    return tuple(_binary_name(name, target) for name in (*REQUIRED_TOOLS, "clangd"))
+    compiled = tuple(_binary_name(name, target) for name in ("clang-format", "clang-query", "clang-tidy", "clangd"))
+    return (*compiled, "git-clang-format", "run-clang-tidy")
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Closes #55

Keep git-clang-format and un-clang-tidy as suffixless helper scripts on Windows, matching the existing clang-extra archive contract; only compiled binaries receive .exe. Update native validation accordingly.

Tests: python -m pytest tests/test_clang_extra_builder.py -q (5 passed).