### PR TITLE
fix: install clang-extra index dependencies

### DIFF
--- a/.github/workflows/build-clang-extra.yml
+++ b/.github/workflows/build-clang-extra.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install pyzstd
+      - run: python -m pip install pyzstd fasteners json5
       - name: Build from exact upstream distribution
         run: >-
           python tools/create_clang_extra_archives.py --download
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install pyzstd
+      - run: python -m pip install pyzstd fasteners json5
       - name: Build pinned clangd source fallback
         shell: bash
         run: |


### PR DESCRIPTION
Closes #55

Install the runtime dependencies imported by archive-index generation (asteners and json5) in the native clang-extra workflow alongside pyzstd. This fixes the current workflow failure before artifact validation.

Tests: YAML parse and focused local builder tests passed previously; failure reproduced from Actions logs at the index-generation step.