### PR TITLE
fix: report clangd runtime validation diagnostics

### DIFF
--- a/tools/validate_clang_extra.py
+++ b/tools/validate_clang_extra.py
@@ -46,9 +46,18 @@ def validate(archive: Path, target: str, expected_major: str, run_check: bool = 
             environment["LD_LIBRARY_PATH"] = str(root / "lib") + os.pathsep + environment.get("LD_LIBRARY_PATH", "")
         elif target == "darwin":
             environment["DYLD_LIBRARY_PATH"] = str(root / "lib") + os.pathsep + environment.get("DYLD_LIBRARY_PATH", "")
-        version = subprocess.run(
-            [str(clangd), "--version"], check=True, capture_output=True, text=True, env=environment
-        ).stdout
+        version_result = subprocess.run([str(clangd), "--version"], capture_output=True, text=True, env=environment)
+        if version_result.returncode != 0:
+            dependency_output = ""
+            if target == "darwin":
+                dependency_output = subprocess.run(
+                    ["otool", "-L", str(clangd)], capture_output=True, text=True
+                ).stdout
+            raise AssertionError(
+                f"clangd --version failed with exit code {version_result.returncode}:\n"
+                f"{version_result.stdout}\n{version_result.stderr}\n{dependency_output}"
+            )
+        version = version_result.stdout
         if f"version {expected_major}." not in version and f"LLVM {expected_major}" not in version:
             raise AssertionError(f"unexpected clangd version: {version.strip()}")
 


### PR DESCRIPTION
Closes #55

Capture non-zero clangd --version exits and include macOS otool -L output. The native ARM64 lane currently aborts during startup; this makes the packaged dependency failure actionable instead of hiding the reason behind CalledProcessError.

Tests: focused builder tests pass.