### PR TITLE
ci: parallelize macOS clangd fallback build

### DIFF
--- a/.github/workflows/build-clang-extra.yml
+++ b/.github/workflows/build-clang-extra.yml
@@ -87,7 +87,7 @@ jobs:
             -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra' \
             -DLLVM_TARGETS_TO_BUILD=X86 \
             -DLLVM_ENABLE_ASSERTIONS=OFF
-          cmake --build llvm-build --target clangd
+          cmake --build llvm-build --target clangd --parallel "$(sysctl -n hw.ncpu)"
           python - <<'PY'
           from pathlib import Path
           import pyzstd, tarfile


### PR DESCRIPTION
Relates to #55. Use all available macOS runner cores for the pinned LLVM source fallback so the required native clangd validation completes deterministically. This PR does not close the issue; closure remains gated on real artifacts, indexes, release, and clean-install evidence.