### PR TITLE
fix: query managed rust sysroot correctly

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -230,7 +230,7 @@ jobs:
           # absent. Reinstall the target and verify the sysroot contents.
           soldr rustup target remove --toolchain "$TOOLCHAIN" "$TARGET" || true
           soldr rustup target add --toolchain "$TOOLCHAIN" "$TARGET"
-          SYSROOT="$(soldr rustc +"$TOOLCHAIN" --print sysroot)"
+          SYSROOT="$(soldr rustc --print sysroot)"
           test -d "$SYSROOT/lib/rustlib/$TARGET/lib"
 
       - name: Install musl tools (x86_64-linux-musl)


### PR DESCRIPTION
## Summary\n- correct the soldr rustc sysroot probe after forced target refresh\n- avoid passing unsupported +stable syntax to soldr rustc\n\nRelates to #55\n\n## Validation\n- release run 29375368424 failed all target jobs at the sysroot probe with couldn't read +stable\n- prior PR CI passed before this final workflow correction