### PR TITLE
fix: preserve crate archives for release attestation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -373,6 +373,11 @@ jobs:
               sleep 30
             fi
           done
+          # cargo publish may remove its staging archive after upload. Create
+          # fresh, byte-identical package archives for the provenance step.
+          for crate in ctcb-core ctcb-checksum ctcb-archive ctcb-dedup ctcb-download ctcb-strip ctcb-manifest ctcb-split ctcb-cli; do
+            cargo package -p "$crate" --no-verify --allow-dirty
+          done
       - name: Attest crate artifacts (GitHub provenance)
         # cargo publish leaves <crate>-<version>.crate in target/package/.
         # Attesting after publish is fine — the bytes are identical to what


### PR DESCRIPTION
## Summary\n- explicitly package each crate after publishing\n- leave fresh archives for GitHub provenance attestation\n- unblock Create GitHub Release after all platform builds pass\n\nRelates to #55\n\n## Validation\n- release run 29376843079 passed all eight platform builds\n- failed only because target/package/*.crate was absent during attestation