### PR TITLE
fix: stream single-file downloads without zccache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-archive"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-checksum"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "md-5",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "serde",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-dedup"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-download"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-manifest"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-core",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-split"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-checksum",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "ctcb-strip"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "ctcb-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/clang_tool_chain_bins/_impl/install.py
+++ b/clang_tool_chain_bins/_impl/install.py
@@ -12,6 +12,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse, unquote
+from urllib.request import urlopen
 
 import fasteners
 import pyzstd
@@ -85,6 +86,16 @@ def _copy_multipart_file_urls(urls: list[str], destination: Path) -> None:
                 raise ValueError(f"expected file:// URL, got {url}")
             with source_path.open("rb") as in_f:
                 shutil.copyfileobj(in_f, out_f)
+
+
+def _fetch_with_http(url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urlopen(url, timeout=60) as response, destination.open("wb") as out_f:
+            shutil.copyfileobj(response, out_f, length=1024 * 1024)
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
 
 
 def _zccache_binary_name() -> str:
@@ -205,7 +216,7 @@ def _fetch_archive(match: dict[str, Any], destination: Path) -> None:
     if _local_file_path_from_url(archive_url) is not None:
         _copy_file_url(archive_url, destination)
         return
-    _fetch_with_zccache(archive_url, destination, match["archive_sha256"])
+    _fetch_with_http(archive_url, destination)
 
 
 def _validated_member_path(base_dir: Path, member_name: str) -> Path:

--- a/crates/ctcb-archive/Cargo.toml
+++ b/crates/ctcb-archive/Cargo.toml
@@ -15,7 +15,7 @@ walkdir = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
 flate2 = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-cli/Cargo.toml
+++ b/crates/ctcb-cli/Cargo.toml
@@ -19,14 +19,14 @@ crate-type = ["cdylib", "rlib"]
 clap = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.5" }
-ctcb-archive = { path = "../ctcb-archive", version = "0.4.5" }
-ctcb-dedup = { path = "../ctcb-dedup", version = "0.4.5" }
-ctcb-download = { path = "../ctcb-download", version = "0.4.5" }
-ctcb-strip = { path = "../ctcb-strip", version = "0.4.5" }
-ctcb-manifest = { path = "../ctcb-manifest", version = "0.4.5" }
-ctcb-split = { path = "../ctcb-split", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.6" }
+ctcb-archive = { path = "../ctcb-archive", version = "0.4.6" }
+ctcb-dedup = { path = "../ctcb-dedup", version = "0.4.6" }
+ctcb-download = { path = "../ctcb-download", version = "0.4.6" }
+ctcb-strip = { path = "../ctcb-strip", version = "0.4.6" }
+ctcb-manifest = { path = "../ctcb-manifest", version = "0.4.6" }
+ctcb-split = { path = "../ctcb-split", version = "0.4.6" }
 walkdir = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/ctcb-dedup/Cargo.toml
+++ b/crates/ctcb-dedup/Cargo.toml
@@ -14,8 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }
 anyhow = { workspace = true }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.5" }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.6" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-download/Cargo.toml
+++ b/crates/ctcb-download/Cargo.toml
@@ -14,5 +14,5 @@ tokio = { workspace = true }
 sha2 = { workspace = true }
 anyhow = { workspace = true }
 indicatif = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
 futures-util = { workspace = true }

--- a/crates/ctcb-manifest/Cargo.toml
+++ b/crates/ctcb-manifest/Cargo.toml
@@ -12,7 +12,7 @@ description = "Two-tier manifest JSON management for clang toolchain binary buil
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-split/Cargo.toml
+++ b/crates/ctcb-split/Cargo.toml
@@ -12,8 +12,8 @@ description = "Archive splitting for Git LFS limits for clang toolchain binary b
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
-ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
+ctcb-checksum = { path = "../ctcb-checksum", version = "0.4.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ctcb-strip/Cargo.toml
+++ b/crates/ctcb-strip/Cargo.toml
@@ -11,7 +11,7 @@ description = "LLVM binary stripping and filtering for clang toolchain binary bu
 [dependencies]
 walkdir = { workspace = true }
 anyhow = { workspace = true }
-ctcb-core = { path = "../ctcb-core", version = "0.4.5" }
+ctcb-core = { path = "../ctcb-core", version = "0.4.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clang-tool-chain-bins"
-version = "0.4.5"
+version = "0.4.6"
 description = "LLVM/Clang Toolchain Build Tools - Rust-powered toolchain packaging with Python bindings"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -117,7 +117,7 @@ class InstallTests(unittest.TestCase):
             self.assertTrue(cache_path.exists())
             self.assertEqual(sha256_file(cache_path), match["archive_sha256"])
 
-    def test_ensure_cached_uses_zccache_for_http_downloads(self) -> None:
+    def test_ensure_cached_uses_direct_http_for_single_file_downloads(self) -> None:
         with TemporaryDirectory() as tmp:
             tmp_root = Path(tmp)
             archive_path = tmp_root / "archives" / "llvm-21.1.5-linux-x86_64.tar.zst"
@@ -126,18 +126,56 @@ class InstallTests(unittest.TestCase):
             match["archive_url"] = "https://example.invalid/llvm-21.1.5-linux-x86_64.tar.zst"
             home_dir = tmp_root / "home"
 
-            def _fake_fetch(source: str | list[str], destination: Path, expected_sha256: str) -> None:
+            def _fake_fetch(source: str, destination: Path) -> None:
                 self.assertEqual(source, match["archive_url"])
-                self.assertEqual(expected_sha256, match["archive_sha256"])
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(archive_path, destination)
 
-            with patch("tools.install._fetch_with_zccache", side_effect=_fake_fetch) as fetch_mock:
+            with patch("tools.install._fetch_with_http", side_effect=_fake_fetch) as fetch_mock:
                 cache_path = install._ensure_cached(match, home_dir)
 
             self.assertTrue(cache_path.exists())
             self.assertEqual(sha256_file(cache_path), match["archive_sha256"])
             fetch_mock.assert_called_once()
+
+    def test_fetch_with_http_streams_response_and_removes_partial_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "cache" / "archive.tar.zst"
+            payload = b"streamed archive"
+
+            class ChunkedResponse(io.BytesIO):
+                requested_sizes: list[int]
+
+                def __init__(self, content: bytes) -> None:
+                    super().__init__(content)
+                    self.requested_sizes = []
+
+                def read(self, size: int = -1) -> bytes:
+                    if size < 0:
+                        raise AssertionError("download attempted an unbounded read")
+                    self.requested_sizes.append(size)
+                    return super().read(min(size, 3))
+
+            response = ChunkedResponse(payload)
+            with patch("tools.install.urlopen", return_value=response) as urlopen_mock:
+                install._fetch_with_http("https://example.invalid/archive.tar.zst", destination)
+
+            self.assertEqual(destination.read_bytes(), payload)
+            self.assertGreater(len(response.requested_sizes), 1)
+            self.assertEqual(set(response.requested_sizes), {1024 * 1024})
+            urlopen_mock.assert_called_once_with("https://example.invalid/archive.tar.zst", timeout=60)
+
+            class BrokenResponse(io.BytesIO):
+                def read(self, size: int = -1) -> bytes:
+                    data = super().read(size)
+                    if data:
+                        return data
+                    raise OSError("connection lost")
+
+            with patch("tools.install.urlopen", return_value=BrokenResponse(b"partial")):
+                with self.assertRaisesRegex(OSError, "connection lost"):
+                    install._fetch_with_http("https://example.invalid/archive.tar.zst", destination)
+            self.assertFalse(destination.exists())
 
     def test_ensure_cached_uses_zccache_for_http_multipart_downloads(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- route ordinary single-file HTTP archives through bounded direct streaming instead of the zccache download daemon
- preserve zccache for multipart archives, remove partial direct downloads on failure, and keep SHA-256 verification before cache promotion
- add regression coverage for single-file routing, 1 MiB bounded streaming, stalled-read timeout configuration, and partial-file cleanup
- bump the release to 0.4.6

## Validation

- `python -m pytest tests/test_clang_extra_builder.py tests/test_clang_extra_validator.py tests/test_query.py tests/test_install.py tests/test_api.py -q` (64 passed)
- `python -m unittest tests.test_install` (26 passed)
- `python -m ruff check clang_tool_chain_bins/_impl/install.py tests/test_install.py`
- `soldr cargo check --workspace`
- `python ci/release_lint.py`
- `git diff --check`
- `clud-review: clean`

## Reproduction evidence

Published 0.4.5 native ARM64 install failure: https://github.com/zackees/clang-tool-chain-bins/actions/runs/29395418960

Closes #73